### PR TITLE
Application token cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,6 @@ tmp/
 node_modules/
 package.json
 package_lock.json
+coverage/
+spec/
+log/*.log

--- a/Gemfile
+++ b/Gemfile
@@ -3,40 +3,19 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.5.1'
 
-# Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'dotenv-rails', require: 'dotenv/rails-now', group: [:development, :test]
 
 gem 'jwt'
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.2.1'
-# database for Active Record
 gem 'sqlite3'
-# Use Puma as the app server
 gem 'puma', '~> 3.11'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-# gem 'jbuilder', '~> 2.5'
-# Use Redis adapter to run Action Cable in production
 gem 'redis', '~> 4.0'
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use ActiveStorage variant
-# gem 'mini_magick', '~> 4.8'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
-
-
-# Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15', '< 4.0'
   gem 'rspec-rails', '>= 3.5.0'
 end
@@ -56,7 +35,6 @@ group :test do
   gem 'simplecov'
   gem 'webmock'
 end
-
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ end
 
 group :development do
   gem 'listen'
+  gem 'guard-rspec', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,7 @@ GEM
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     cliver (0.3.2)
+    coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -79,8 +80,23 @@ GEM
     faker (1.9.1)
       i18n (>= 0.7)
     ffi (1.9.25)
+    formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    guard (2.15.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
     hashdiff (0.3.7)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
@@ -93,6 +109,7 @@ GEM
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    lumberjack (1.0.13)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
@@ -103,14 +120,21 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.2.4)
+    nenv (0.3.0)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
+    notiffany (0.1.1)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
     phantomjs (2.1.1.0)
     poltergeist (1.18.1)
       capybara (>= 2.1, < 4)
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
@@ -145,6 +169,10 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redis (4.0.2)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -168,6 +196,7 @@ GEM
     selenium-webdriver (3.14.1)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
+    shellany (0.0.1)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
     simplecov (0.16.1)
@@ -208,6 +237,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails (~> 4.0)
   faker
+  guard-rspec
   jwt
   listen
   phantomjs
@@ -227,4 +257,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.4
+   1.17.2

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,71 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features) \
+#  .select{|d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist")}
+
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
+#  * 'just' rspec: 'rspec'
+
+guard :rspec, cmd: "bundle exec rspec", all_on_start: true,
+                                        all_after_pass: true do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # Feel free to open issues for suggestions and improvements
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+
+  # Rails files
+  rails = dsl.rails(view_extensions: %w(erb haml slim))
+  dsl.watch_spec_files_for(rails.app_files)
+  dsl.watch_spec_files_for(rails.views)
+
+  watch(rails.controllers) do |m|
+    [
+      rspec.spec.call("routing/#{m[1]}_routing"),
+      rspec.spec.call("controllers/#{m[1]}_controller"),
+      rspec.spec.call("acceptance/#{m[1]}")
+    ]
+  end
+
+  # Rails config changes
+  watch(rails.spec_helper)     { rspec.spec_dir }
+  watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
+  watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+
+  # Capybara features specs
+  watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
+  watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+
+  # Turnip features and steps
+  watch(%r{^spec/acceptance/(.+)\.feature$})
+  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
+    Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
+  end
+end

--- a/app/services/adapters/kubectl_adapter.rb
+++ b/app/services/adapters/kubectl_adapter.rb
@@ -1,13 +1,21 @@
 class Adapters::KubectlAdapter
   attr_reader :secret_name, :namespace
 
-  def self.get_secret(name)
-    instance = new(secret_name: name)
+  def self.get_service_secret(name)
+    namespace = ENV['KUBECTL_SERVICES_NAMESPACE']
+    instance = new(secret_name: name, namespace: namespace)
     instance.get_secret
   end
 
-  def initialize(secret_name:)
+  def self.get_platform_secret(name)
+    namespace = ENV['KUBECTL_PLATFORM_NAMESPACE']
+    instance = new(secret_name: name, namespace: namespace)
+    instance.get_secret
+  end
+
+  def initialize(secret_name:, namespace:)
     @secret_name = secret_name
+    @namespace = namespace
   end
 
   def get_secret
@@ -32,8 +40,7 @@ class Adapters::KubectlAdapter
   end
 
   def kubectl_args(context: ENV['KUBECTL_CONTEXT'],
-                   bearer_token: ENV['KUBECTL_BEARER_TOKEN'],
-                   namespace: ENV['KUBECTL_SERVICES_NAMESPACE'])
+                   bearer_token: ENV['KUBECTL_BEARER_TOKEN'])
     args = []
     args << '--context=' + context unless context.blank?
     args << '--namespace=' + namespace unless namespace.blank?

--- a/app/services/adapters/kubectl_adapter.rb
+++ b/app/services/adapters/kubectl_adapter.rb
@@ -19,13 +19,15 @@ class Adapters::KubectlAdapter
   end
 
   def get_secret
+    return nil if json.blank?
+
     Base64.decode64(JSON.parse(json)['data']['token'])
   end
 
   private
 
   def json
-    Adapters::ShellAdapter.output_of(kubectl_cmd)
+    @json ||= Adapters::ShellAdapter.output_of(kubectl_cmd)
   end
 
   def kubectl_cmd
@@ -45,6 +47,7 @@ class Adapters::KubectlAdapter
     args << '--context=' + context unless context.blank?
     args << '--namespace=' + namespace unless namespace.blank?
     args << '--token=' + bearer_token  unless bearer_token.blank?
+    args << '--ignore-not-found=true'
 
     args.compact.join(' ')
   end

--- a/app/services/support/service_token_authoritative_source.rb
+++ b/app/services/support/service_token_authoritative_source.rb
@@ -1,12 +1,22 @@
 class Support::ServiceTokenAuthoritativeSource
   def self.get(service_slug)
-    Adapters::KubectlAdapter.get_secret(
-      secret_name(service_slug)
-    )
+    Adapters::KubectlAdapter.get_platform_secret(platform_secret_name(service_slug)) || Adapters::KubectlAdapter.get_service_secret(service_secret_name(service_slug))
   end
 
-  def self.secret_name(service_slug)
+  def self.get_service_secret(slug)
+    Adapters::KubectlAdapter.get_secret(service_secret_name(service_slug))
+  end
+
+  def self.get_platform_secret(slug)
+    Adapters::KubectlAdapter.get_secret(platform_secret_name(service_slug))
+  end
+
+  def self.service_secret_name(service_slug)
     ['fb-service', service_slug, 'token', environment_slug].join('-')
+  end
+
+  def self.platform_secret_name(service_slug)
+    ['fb-platform', service_slug, 'token', environment_slug].join('-')
   end
 
   private

--- a/deploy/fb-service-token-cache-chart/templates/deployment.yaml
+++ b/deploy/fb-service-token-cache-chart/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
                 key: token
           - name: KUBECTL_SERVICES_NAMESPACE
             value: formbuilder-services-{{ .Values.environmentName }}
+          - name: KUBECTL_PLATFORM_NAMESPACE
+            value: formbuilder-platform-{{ .Values.environmentName }}
           # secrets created by terraform
           # to access infrastructure defined in
           # cloud-platforms-environments

--- a/spec/services/adapters/kubectl_adapter_spec.rb
+++ b/spec/services/adapters/kubectl_adapter_spec.rb
@@ -2,13 +2,18 @@ require 'rails_helper'
 
 describe Adapters::KubectlAdapter do
   let(:secret_name) { 'my-secret' }
+
   before do
     allow(Adapters::ShellAdapter).to receive(:output_of).and_return('some output')
   end
 
-  describe '.get_secret' do
+  subject do
+    described_class.new(secret_name: secret_name)
+  end
+
+  describe '#get_secret' do
     let(:kubectl_output) { 'kubectl output]' }
-    let(:parsed_json) {
+    let(:parsed_json) do
       {
         'data' => {
           'a_key' => 'a value',
@@ -16,98 +21,37 @@ describe Adapters::KubectlAdapter do
           'token' => 'token value'
         }
       }
-    }
+    end
+
     before do
       allow(JSON).to receive(:parse).with(kubectl_output).and_return(parsed_json)
       allow(Base64).to receive(:decode64).with('token value').and_return('decoded token')
-      allow(described_class).to receive(:kubectl_cmd).and_return('kubectl cmd')
+      allow(subject).to receive(:kubectl_cmd).and_return('kubectl cmd')
       allow(Adapters::ShellAdapter).to receive(:output_of).with('kubectl cmd').and_return(kubectl_output)
     end
 
     it 'calls kubectl_cmd passing the given secret name' do
-      expect(described_class).to receive(:kubectl_cmd).with(secret_name)
-      described_class.get_secret(secret_name)
+      expect(subject).to receive(:kubectl_cmd)
+      subject.get_secret
     end
 
     it 'gets the output of the kubectl_cmd' do
       expect(Adapters::ShellAdapter).to receive(:output_of).with('kubectl cmd').and_return(kubectl_output)
-      described_class.get_secret(secret_name)
+      subject.get_secret
     end
 
     it 'parses the kubectl output as JSON' do
       expect(JSON).to receive(:parse).with(kubectl_output).and_return(parsed_json)
-      described_class.get_secret(secret_name)
+      subject.get_secret
     end
 
     it 'base64-decodes the [data][token] key' do
       expect(Base64).to receive(:decode64).with('token value').and_return('decoded token')
-      described_class.get_secret(secret_name)
+      subject.get_secret
     end
 
     it 'returns the decoded token' do
-      expect(described_class.get_secret(secret_name)).to eq('decoded token')
-      described_class.get_secret(secret_name)
+      expect(subject.get_secret).to eq('decoded token')
     end
-  end
-
-  describe '.kubectl_args' do
-    let(:context) {}
-    let(:namespace) {}
-    let(:bearer_token) {}
-    let(:args) {
-      {
-        context: context,
-        namespace: namespace,
-        bearer_token: bearer_token
-      }
-    }
-    let(:return_value) { described_class.kubectl_args(args) }
-
-    it 'returns a string' do
-      expect(return_value).to be_a(String)
-    end
-
-    context 'given no values' do
-      it 'returns an empty string' do
-        expect(return_value).to be_empty
-      end
-    end
-
-    context 'given a context' do
-      let(:context) { 'my-context' }
-
-      it 'includes --context=(context)' do
-        expect(return_value).to include('--context=my-context')
-      end
-
-      context 'and a namespace' do
-        let(:namespace) { 'my-namespace' }
-
-        it 'includes --namespace=(namespace)' do
-          expect(return_value).to include('--namespace=my-namespace')
-        end
-        it 'includes --context=(context)' do
-          expect(return_value).to include('--context=my-context')
-        end
-      end
-    end
-
-    context 'given a namespace' do
-      let(:namespace) { 'my-namespace' }
-
-      it 'includes --namespace=(namespace)' do
-        expect(return_value).to include('--namespace=my-namespace')
-      end
-    end
-
-    context 'given a bearer_token' do
-      let(:bearer_token) { 'my-bearer_token' }
-
-      it 'includes --token=(bearer_token)' do
-        expect(return_value).to include('--token=my-bearer_token')
-      end
-    end
-
-
   end
 end

--- a/spec/services/adapters/kubectl_adapter_spec.rb
+++ b/spec/services/adapters/kubectl_adapter_spec.rb
@@ -54,5 +54,15 @@ describe Adapters::KubectlAdapter do
     it 'returns the decoded token' do
       expect(subject.get_secret).to eq('decoded token')
     end
+
+    context 'when shell adapter retruns empty string' do
+      before :each do
+        expect(Adapters::ShellAdapter).to receive(:output_of).with('kubectl cmd').and_return('')
+      end
+
+      it 'returns nil' do
+        expect(subject.get_secret).to be_nil
+      end
+    end
   end
 end

--- a/spec/services/adapters/kubectl_adapter_spec.rb
+++ b/spec/services/adapters/kubectl_adapter_spec.rb
@@ -2,13 +2,14 @@ require 'rails_helper'
 
 describe Adapters::KubectlAdapter do
   let(:secret_name) { 'my-secret' }
+  let(:namespace) { 'my-namespace' }
 
   before do
     allow(Adapters::ShellAdapter).to receive(:output_of).and_return('some output')
   end
 
   subject do
-    described_class.new(secret_name: secret_name)
+    described_class.new(secret_name: secret_name, namespace: namespace)
   end
 
   describe '#get_secret' do


### PR DESCRIPTION
- This changes the underlying responsibility of service token cache to now become an application token cache. This enables all components to determine if messages from any other component is acceptable
- This checks platform base components first then service components in that order
- Also refactored out some class methods to use instance methods internally instead