### PR TITLE
Rolling deployments

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -27,10 +27,6 @@ To use the following scripts, first run `npm install`
 
   Script to initialise/update Kubernetes deployments for a platform environment
 
-- `scripts/restart_platform_pods.sh`
-
-  Script to explicitly restart pods in a platform environment
-
 All these scripts print out their usage instructions by being run with the `-h` flag
 
 ## Configuration files
@@ -90,29 +86,9 @@ See the `Makefile` for more info.
     - `secret_key_base`
       Rails secret
 
-- Run the `scripts/deploy_platform.sh` script which 
+- Run the `scripts/deploy_platform.sh` script which
 
   - generates the necessary kubernetees configuration to deploy the application
   - applies the configuration
 
 The generated config for each platform/deployment environment combination is written to `/tmp/fb-service-token-cache-$PLATFORM_ENV-$DEPLOYMENT_ENV.yaml`
-
-### 4. Deploying an updated docker image to existing infrastructure
-
-Deleting the currently running pods will trigger the kubernetes Deployment to recreate pods until it has its specified minimum number running - as the Deployment has `imagePullPolicy: Always`, it will pull the latest docker image from Cloud Platform's ECR.
-
-`scripts/restart_platform_pods.sh` is a convenience script that deletes all pods in all deployment environments accross a platform environment.
-
-Running
-
-```bash
-scripts/restart_platform_pods.sh -p $PLATFORM_ENV
-```
-
-is equivalent to
-
-```bash
-kubectl delete pods -l appGroup=fb-service-token-cache --namespace=formbuilder-platform-$PLATFORM_ENV-dev &\
-kubectl delete pods -l appGroup=fb-service-token-cache --namespace=formbuilder-platform-$PLATFORM_ENV-staging &\
-kubectl delete pods -l appGroup=fb-service-token-cache --namespace=formbuilder-platform-$PLATFORM_ENV-production &
-```

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,12 @@ target:
 ifeq ($(TARGETDEFINED), "true")
 	$(eval export env_stub=${TARGET})
 	@true
-else 
+else
 	$(info Must set TARGET)
 	@false
 endif
 
 init:
-	$(eval export ECR_REPO_NAME=fb-service-token-cache)
 	$(eval export ECR_REPO_URL=754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-service-token-cache)
 
 # install aws cli w/o sudo
@@ -39,17 +38,15 @@ install_build_dependencies: init
 	pip install --user awscli
 	$(eval export PATH=${PATH}:${HOME}/.local/bin/)
 
-
-# Needs ECR_REPO_NAME & ECR_REPO_URL env vars
 build: install_build_dependencies
-	docker build -t ${ECR_REPO_NAME}:latest-${env_stub} -f Dockerfile . && \
-		docker tag ${ECR_REPO_NAME}:latest-${env_stub} ${ECR_REPO_URL}:latest-${env_stub}
+	docker build -t ${ECR_REPO_URL}:latest-${env_stub} -t ${ECR_REPO_URL}:${CIRCLE_SHA1} -f ./Dockerfile .
 
 login: init
 	@eval $(shell aws ecr get-login --no-include-email --region eu-west-2)
 
 push: login
 	docker push ${ECR_REPO_URL}:latest-${env_stub}
+	docker push ${ECR_REPO_URL}:${CIRCLE_SHA1} #multiple tags in ECR can only be done by pushing twice
 
 build_and_push: build push
 

--- a/deploy/fb-service-token-cache-chart/templates/deployment.yaml
+++ b/deploy/fb-service-token-cache-chart/templates/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: "formbuilder-service-token-cache-{{ .Values.environmentName }}"
       containers:
       - name: "fb-service-token-cache-{{ .Values.environmentName }}"
-        image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-service-token-cache:latest-{{ .Values.platformEnv }}"
+        image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-service-token-cache:{{ .Values.circleSha1 }}"
         securityContext:
           runAsUser: 1001
         imagePullPolicy: Always

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/ministryofjustice/fb-service-token-cache#readme",
   "dependencies": {},
   "devDependencies": {
-    "@ministryofjustice/fb-deploy-utils": "^1.0.6"
+    "@ministryofjustice/fb-deploy-utils": "^1.0.10"
   }
 }

--- a/scripts/circleci_deploy.sh
+++ b/scripts/circleci_deploy.sh
@@ -20,7 +20,4 @@ echo "kubectl use circleci context"
 kubectl config use-context "circleci_${environment_name}_${deployment_name}"
 
 echo "apply kubernetes changes to ${environment_name} ${deployment_name}"
-./scripts/deploy_platform.sh -p $environment_name -d $deployment_name
-
-echo "delete pods in ${environment_name} ${deployment_name}"
-./scripts/restart_platform_pods.sh -p $environment_name -d $deployment_name -c "circleci_${environment_name}_${deployment_name}"
+./scripts/deploy_platform.sh -p $environment_name -d $deployment_name -s $CIRCLE_SHA1

--- a/scripts/restart_platform_pods.sh
+++ b/scripts/restart_platform_pods.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-FB_APPLICATION='fb-service-token-cache' node_modules/\@ministryofjustice/fb-deploy-utils/bin/restart_platform_pods.sh $@


### PR DESCRIPTION
Instead of manually deleting pods (resulting in downtime), use kubernetes
built-in rolling deployments.  This requires a dynamic tag on the container
image that can be referred to by the Helm deployment.yaml file.

By simply using a tag like latest, that never changes, kubernetes won't pick up
that anything has changed and not deploy.