### PR TITLE
Add minimum coverage and format output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ group :test do
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 3.1'
   gem 'simplecov'
+  gem 'simplecov-console', require: false
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    ansi (1.5.0)
     arel (9.0.0)
     bootsnap (1.3.2)
       msgpack (~> 1.0)
@@ -203,6 +204,10 @@ GEM
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
+    simplecov-console (0.5.0)
+      ansi
+      simplecov
+      terminal-table
     simplecov-html (0.10.2)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -212,10 +217,13 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.13)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unicode-display_width (1.6.0)
     webmock (3.4.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -249,6 +257,7 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers (~> 3.1)
   simplecov
+  simplecov-console
   sqlite3
   tzinfo-data
   webmock

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,7 +96,14 @@ RSpec.configure do |config|
 end
 
 require 'simplecov'
+require 'simplecov-console'
+
 SimpleCov.start do
   add_filter '/config/'
   add_filter '/spec/'
 end
+SimpleCov.minimum_coverage 79
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::Console
+])


### PR DESCRIPTION
I've added a minimum code coverage at the current coverage level to ensure code coverage does not decrease. We can work towards 100% coverage in subsequent PRs.

Also added a nice formatter to clearly display coverage results:
<img width="898" alt="Screenshot 2019-06-25 at 16 50 26" src="https://user-images.githubusercontent.com/2160769/60113318-69914880-9769-11e9-99e4-6322e3ca9775.png">
