### PR TITLE
Add Kubernetes readiness probe

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,5 @@
+class HealthController < ApplicationController
+  def show
+    render plain: 'healthy'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get '/health', to: 'health#show'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/service/:service_slug', to: 'service_token#show'
 end

--- a/deploy/fb-service-token-cache-chart/templates/deployment.yaml
+++ b/deploy/fb-service-token-cache-chart/templates/deployment.yaml
@@ -22,6 +22,14 @@ spec:
         imagePullPolicy: Always
         ports:
           - containerPort: 3000
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+
         # non-secret env vars
         # defined in config_map.yaml
         envFrom:

--- a/spec/requests/health_spec.rb
+++ b/spec/requests/health_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe 'health', type: :request do
+  describe 'GET /health' do
+    it 'responds with healthy' do
+      get '/health'
+      expect(response.status).to eq(200)
+      expect(response.body).to eq('healthy')
+    end
+  end
+end


### PR DESCRIPTION
Even though we are doing rolling deploys, it seems that traffic is being served
to the pods before Rails has booted. So this is still resulting in downtime.

By exposing an endpoint for the readiness probe to test, we can ensure that the application
will be ready to serve traffic by the time it is registered with the load balancer.