### PR TITLE
add public key endpoint

### DIFF
--- a/app/controllers/service_token_v2_controller.rb
+++ b/app/controllers/service_token_v2_controller.rb
@@ -2,6 +2,10 @@ class ServiceTokenV2Controller < ApplicationController
   def show
     token = Support::ServiceTokenAuthoritativeSource.get_public_key(service_slug: params[:service_slug])
 
-    render json: {token: token}, status: 200
+    if token.present?
+      render json: { token: token }, status: 200
+    else
+      head :not_found
+    end
   end
 end

--- a/app/controllers/service_token_v2_controller.rb
+++ b/app/controllers/service_token_v2_controller.rb
@@ -1,0 +1,7 @@
+class ServiceTokenV2Controller < ApplicationController
+  def show
+    token = Support::ServiceTokenAuthoritativeSource.get_public_key(service_slug: params[:service_slug])
+
+    render json: {token: token}, status: 200
+  end
+end

--- a/app/services/adapters/kubectl_adapter.rb
+++ b/app/services/adapters/kubectl_adapter.rb
@@ -16,6 +16,8 @@ class Adapters::KubectlAdapter
   def initialize(secret_name:, namespace:)
     @secret_name = secret_name
     @namespace = namespace
+
+    validate_params!
   end
 
   def get_secret
@@ -38,6 +40,16 @@ class Adapters::KubectlAdapter
   end
 
   private
+
+  def validate_params!
+    if !secret_name.match(/\A[a-zA-Z0-9\-_]*\z/)
+      raise ArgumentError.new('rejected potentially dangerous secret_name')
+    end
+
+    if !namespace.match(/\A[a-zA-Z0-9\-_]*\z/)
+      raise ArgumentError.new('rejected potentially dangerous namespace')
+    end
+  end
 
   def json
     @json ||= Adapters::ShellAdapter.output_of(kubectl_cmd)

--- a/app/services/adapters/kubectl_adapter.rb
+++ b/app/services/adapters/kubectl_adapter.rb
@@ -24,6 +24,19 @@ class Adapters::KubectlAdapter
     Base64.decode64(JSON.parse(json)['data']['token'])
   end
 
+  def get_public_key
+    command = [
+      kubectl_binary,
+      'get',
+      'configmaps',
+      '-o',
+      "jsonpath='{.data.ENCODED_PUBLIC_KEY}'",
+      "fb-#{secret_name}-config-map",
+    ] + [kubectl_args]
+
+    Adapters::ShellAdapter.output_of(command)
+  end
+
   private
 
   def json

--- a/app/services/support/service_token_authoritative_source.rb
+++ b/app/services/support/service_token_authoritative_source.rb
@@ -11,6 +11,12 @@ class Support::ServiceTokenAuthoritativeSource
     Adapters::KubectlAdapter.get_secret(platform_secret_name(service_slug))
   end
 
+  def self.get_public_key(service_slug:)
+    adapter = Adapters::KubectlAdapter.new(secret_name: service_slug,
+                                           namespace: ENV['KUBECTL_SERVICES_NAMESPACE'])
+    adapter.get_public_key
+  end
+
   def self.service_secret_name(service_slug)
     ['fb-service', service_slug, 'token', environment_slug].join('-')
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   get '/health', to: 'health#show'
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get '/service/:service_slug', to: 'service_token#show'
+  get '/service/v2/:service_slug', to: 'service_token_v2#show'
 end

--- a/spec/controllers/service_token_v2_controller_spec.rb
+++ b/spec/controllers/service_token_v2_controller_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe ServiceTokenV2Controller do
     end
 
     context 'when service does not exist' do
+      it 'returns 404' do
+        allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('')
+
+        get :show, params: { service_slug: 'test-service' }
+        expect(response).to be_not_found
+      end
     end
   end
 end

--- a/spec/controllers/service_token_v2_controller_spec.rb
+++ b/spec/controllers/service_token_v2_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe ServiceTokenV2Controller do
+  describe '#show' do
+    it 'returns public key' do
+      allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('v2-public-key')
+
+      get :show, params: { service_slug: 'test-service' }
+      expect(response).to be_successful
+      expect(JSON.parse(response.body)['token']).to eql('v2-public-key')
+    end
+
+    context 'when service does not exist' do
+    end
+  end
+end

--- a/spec/services/adapters/kubectl_adapter_spec.rb
+++ b/spec/services/adapters/kubectl_adapter_spec.rb
@@ -65,4 +65,38 @@ describe Adapters::KubectlAdapter do
       end
     end
   end
+
+  describe '#get_public_key' do
+    context 'when code injection' do
+      context 'with dangerous secret_name' do
+        let(:secret_name) { '; curl https://example.com;' }
+        let(:namespace) { 'some-namespace' }
+
+        subject do
+          described_class.new(secret_name: secret_name, namespace: namespace)
+        end
+
+        it 'raises an error' do
+          expect do
+            subject.get_public_key
+          end.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'with dangerous namespace' do
+        let(:secret_name) { 'some-namespace' }
+        let(:namespace) { '; curl https://example.com;' }
+
+        subject do
+          described_class.new(secret_name: secret_name, namespace: namespace)
+        end
+
+        it 'raises an error' do
+          expect do
+            subject.get_public_key
+          end.to raise_error(ArgumentError)
+        end
+      end
+    end
+  end
 end

--- a/spec/support/json_only_api.rb
+++ b/spec/support/json_only_api.rb
@@ -10,7 +10,7 @@ RSpec.shared_context 'a JSON-only API' do |method_name, url|
     end
 
     it 'responds with the json content type' do
-      expect(response.content_type).to eq('application/json')
+      expect(response.media_type).to eq('application/json')
     end
 
     it 'does not respond_with :unacceptable' do


### PR DESCRIPTION
- this implements another endpoint that now returns the public key of the service which can then be used to verify signatures