### PR TITLE
Replace image from docker hub with aws ecr (in test)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: 'make spec'
   build_and_deploy_to_test:
     working_directory: ~/circle/git/fb-service-token-cache
-    docker:
+    docker: &ecr_base_image
       - image: $AWS_ECR_ACCOUNT_URL
         aws_auth:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
@@ -48,8 +48,7 @@ jobs:
           command: './scripts/circleci_deploy.sh test production $KUBE_TOKEN_TEST_PRODUCTION'
   build_and_deploy_to_live:
     working_directory: ~/circle/git/fb-service-token-cache
-    docker:
-      - image: asmega/fb-builder:latest
+    docker: *ecr_base_image
     steps:
       - checkout
       - add_ssh_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,10 @@ jobs:
   build_and_deploy_to_test:
     working_directory: ~/circle/git/fb-service-token-cache
     docker:
-      - image: asmega/fb-builder:latest
+      - image: $AWS_ECR_ACCOUNT_URL
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
     steps:
       - checkout
       - add_ssh_keys:


### PR DESCRIPTION
[Trello](https://trello.com/c/OP1n7Bve/181-formalise-docker-build-image-for-circleci)

## Description

Replace image from docker hub with aws ecr