### PR TITLE
Add acceptance test workflow to this repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,11 +76,22 @@ jobs:
       - run:
           name: deploy to live production
           command: './scripts/circleci_deploy.sh live production $KUBE_TOKEN_LIVE_PRODUCTION'
+  trigger_acceptance_tests:
+    docker:
+      - image: circleci/ruby:latest
+    steps:
+      - run:
+          name: "Trigger Acceptance Tests"
+          command: "curl -u ${CIRCLE_TOKEN}: -X POST https://circleci.com/api/v2/project/github/ministryofjustice/fb-acceptance-tests/pipeline -H 'Content-Type: application/json' -H 'Accept: application/json'"
 
 workflows:
   version: 2
   test_and_build:
     jobs:
+      - trigger_acceptance_tests:
+          filters:
+            branches:
+              only: master
       - test
       - build_and_deploy_to_test:
           requires:


### PR DESCRIPTION
## Description

After merging #94 it was discovered that this repo doesn't trigger the acceptance test within the workflow, so adding the acceptance tests to boost more reliable applications to test and production.

### Steps taken

* Add CIRCLE TOKEN env to Cicle CI
* Create this PR.