### PR TITLE
Add 4 workers to bundle install to improve performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY Gemfile* .ruby-version ./
 
 ARG BUNDLE_FLAGS
 RUN gem install bundler
-RUN bundle install --no-cache
+RUN bundle install --jobs 4
 
 COPY . .
 


### PR DESCRIPTION
This can give a boost to our bundle install (I see at you Nokogiri!). The no-cache option is deprecated so removing it.