### PR TITLE
Add ability to ignore caching

### DIFF
--- a/app/services/public_key_service.rb
+++ b/app/services/public_key_service.rb
@@ -6,16 +6,23 @@ class PublicKeyService
   end
 
   def call
-    if cached_value
-      cached_value
-    else
-      public_key = Support::ServiceTokenAuthoritativeSource.get_public_key(service_slug: service_slug)
-      adapter.put(key, public_key, ex: ttl_in_seconds)
+    if ActiveModel::Type::Boolean.new.cast(ENV['IGNORE_CACHE'])
       public_key
+    else
+      if cached_value
+        cached_value
+      else
+        adapter.put(key, public_key, ex: ttl_in_seconds)
+        public_key
+      end
     end
   end
 
   private
+
+  def public_key
+    @public_key ||= Support::ServiceTokenAuthoritativeSource.get_public_key(service_slug: service_slug)
+  end
 
   def ttl_in_seconds
     ENV['SERVICE_TOKEN_CACHE_TTL'].to_i

--- a/deploy/fb-service-token-cache-chart/templates/config_map.yaml
+++ b/deploy/fb-service-token-cache-chart/templates/config_map.yaml
@@ -9,3 +9,4 @@ data:
   FB_ENVIRONMENT_SLUG: "{{ .Values.environmentName }}"
   SERVICE_TOKEN_CACHE_TTL: "600"
   RAILS_LOG_TO_STDOUT: "true"
+  IGNORE_CACHE: "false"

--- a/spec/controllers/service_token_v2_controller_spec.rb
+++ b/spec/controllers/service_token_v2_controller_spec.rb
@@ -18,5 +18,19 @@ RSpec.describe ServiceTokenV2Controller do
         expect(response).to be_not_found
       end
     end
+
+    context 'when IGNORE_CACHE is set' do
+      before do
+        ENV.stub(:[]).with('IGNORE_CACHE').and_return('true')
+        allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('v2-public-key')
+        get :show, params: { service_slug: 'test-service' }
+      end
+
+      it 'should return the public key without using the redis cache' do
+        expect(response).to be_successful
+        expect(Adapters::RedisCacheAdapter).not_to receive(:get)
+        expect(Adapters::RedisCacheAdapter).not_to receive(:put)
+      end
+    end
   end
 end


### PR DESCRIPTION
We need to be able to rebuild the redis cluster without causing errors to our end users. We can set a maintenance mode in the runner but it will still request the public key from the service token cache for any request that it gets.

Setting the `IGNORE_CACHE` environment variable will force public key to be requested from where it is stored in the kubernetes cluster for every request.

The rebuilding of the redis cluster does not take too long and we will choose a time where there are lower numbers of users so it should not impact services heavily.

https://trello.com/c/fKay4n3y/575-show-maintenance-page-without-requiring-elasticache-connection