### PR TITLE
Re-enable use of caching

### DIFF
--- a/deploy/fb-service-token-cache-chart/templates/config_map.yaml
+++ b/deploy/fb-service-token-cache-chart/templates/config_map.yaml
@@ -9,4 +9,4 @@ data:
   FB_ENVIRONMENT_SLUG: "{{ .Values.environmentName }}"
   SERVICE_TOKEN_CACHE_TTL: "600"
   RAILS_LOG_TO_STDOUT: "true"
-  IGNORE_CACHE: "true"
+  IGNORE_CACHE: "false"


### PR DESCRIPTION
Once the redis cluster has been rebuilt we can go back to using it

https://trello.com/c/wMjJI6BB/557-communicate-and-carry-out-elasticache-rebuilding