### PR TITLE
Trigger acceptance tests after successful rollout restart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ workflows:
       - confirm_live_deploy:
           type: approval
           requires:
-            - build_and_deploy_to_test
+            - trigger_acceptance_tests
       - build_and_deploy_to_live:
           requires:
             - confirm_live_deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,8 +97,11 @@ jobs:
       - image: circleci/ruby:latest
     steps:
       - run:
+          name: cloning deploy scripts
+          command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
+      - run:
           name: "Trigger Acceptance Tests"
-          command: "curl -u ${CIRCLE_TOKEN}: -X POST https://circleci.com/api/v2/project/github/ministryofjustice/fb-acceptance-tests/pipeline -H 'Content-Type: application/json' -H 'Accept: application/json'"
+          command: './deploy-scripts/bin/acceptance_tests'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,12 +105,6 @@ workflows:
   test_and_build:
     jobs:
       - test
-      - trigger_acceptance_tests:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
       - build_and_deploy_to_test:
           requires:
             - test
@@ -118,6 +112,13 @@ workflows:
             branches:
               only:
                 - master
+      - trigger_acceptance_tests:
+          requires:
+            - test
+            - build_and_deploy_to_test
+          filters:
+            branches:
+              only: master
       - confirm_live_deploy:
           type: approval
           requires:


### PR DESCRIPTION
Now that our deployment pipeline checks for whether a pod has been successfully restarted we can trigger the acceptance tests later.