### PR TITLE
Remove fingerprint from acceptance tests step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,9 +96,6 @@ jobs:
     working_directory: ~/circle/git/fb-service-token-cache
     docker: *ecr_base_image
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "e3:25:34:15:2b:c4:d3:b7:c3:94:9f:50:dd:c3:0f:de"
       - run:
           name: cloning deploy scripts
           command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'


### PR DESCRIPTION
The fb-deploy repo is public and there are no other private repos that need to be cloned in the trigger acceptance tests step.