### PR TITLE
Redact Kubernetes token from messages sent to Sentry

### DIFF
--- a/app/services/adapters/shell_adapter.rb
+++ b/app/services/adapters/shell_adapter.rb
@@ -9,7 +9,10 @@ class Adapters::ShellAdapter
     # TODO: maybe use Open3.popen2e instead, so that we
     # can get streaming output as well as exit code?
     result = Kernel.system(cmd_line)
-    raise CmdFailedError.new(cause: "#{$?}", message: "failing cmd: #{cmd_line}") unless result
+
+    unless result
+      raise CmdFailedError.new(cause: "#{$?}", message: "failing cmd: #{redect_token(cmd_line)}")
+    end
   end
 
   def self.output_of(*args)
@@ -21,12 +24,16 @@ class Adapters::ShellAdapter
 
     stdout_str, status = Open3.capture2(cmd_line, stdin_data: stdin)
     unless status.success?
-      raise CmdFailedError.new(cause: "#{$?}", message: "failing cmd: #{cmd_line}")
+      raise CmdFailedError.new(cause: "#{$?}", message: "failing cmd: #{redact_token(cmd_line)}")
     end
     stdout_str
   end
 
   def self.build_cmd(args)
     args.join(' ')
+  end
+
+  def self.redact_token(message)
+    message.gsub(/(?<=--token=)(.*)(?=\s)/, '<REDACTED>')
   end
 end

--- a/spec/services/adapters/shell_adapter_spec.rb
+++ b/spec/services/adapters/shell_adapter_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe Adapters::ShellAdapter do
+  let(:token) { SecureRandom.uuid }
+  let(:message) do
+    "failing cmd: /some/path/kubectl get configmaps -o jsonpath='{.data.PATRICK_STAR}' fb-spongebob-config-map --namespace=formbuilder-spongebob --token=#{token} --ignore-not-found=true"
+  end
+
+  describe '#redact_token' do
+    context 'when a message needs redacting' do
+      it 'should remove the token from the message' do
+        expect(described_class.redact_token(message)).not_to include(token)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We do not want the Kubernetes token to be printed out in the errors that are sent to Sentry.

https://trello.com/c/LfLkccvb/963-redact-kubernetes-token-in-service-token-cache