### PR TITLE
Add V3 service endpoint

### DIFF
--- a/app/controllers/service_token_v3_controller.rb
+++ b/app/controllers/service_token_v3_controller.rb
@@ -1,0 +1,15 @@
+class ServiceTokenV3Controller < ApplicationController
+  def show
+    service = PublicKeyService.new(
+      service_slug: params[:application],
+      namespace: params[:namespace]
+    )
+    public_key = service.call
+
+    if public_key.present?
+      render json: { token: public_key }, status: 200
+    else
+      head :not_found
+    end
+  end
+end

--- a/app/services/adapters/kubectl_adapter.rb
+++ b/app/services/adapters/kubectl_adapter.rb
@@ -19,6 +19,9 @@ class Adapters::KubectlAdapter
     ] + [kubectl_args]
 
     Adapters::ShellAdapter.output_of(command)
+  rescue CmdFailedError => e
+    Raven.capture_exception(e)
+    ''
   end
 
   private

--- a/app/services/public_key_service.rb
+++ b/app/services/public_key_service.rb
@@ -1,8 +1,9 @@
 class PublicKeyService
-  attr_reader :service_slug
+  attr_reader :service_slug, :namespace
 
-  def initialize(service_slug:)
+  def initialize(service_slug:, namespace: ENV['KUBECTL_SERVICES_NAMESPACE'])
     @service_slug = service_slug
+    @namespace = namespace
   end
 
   def call
@@ -21,7 +22,11 @@ class PublicKeyService
   private
 
   def public_key
-    @public_key ||= Support::ServiceTokenAuthoritativeSource.get_public_key(service_slug: service_slug)
+    @public_key ||=
+      Support::ServiceTokenAuthoritativeSource.get_public_key(
+        service_slug: service_slug,
+        namespace: namespace
+      )
   end
 
   def ttl_in_seconds

--- a/app/services/support/service_token_authoritative_source.rb
+++ b/app/services/support/service_token_authoritative_source.rb
@@ -1,7 +1,7 @@
 class Support::ServiceTokenAuthoritativeSource
-  def self.get_public_key(service_slug:)
+  def self.get_public_key(service_slug:, namespace:)
     adapter = Adapters::KubectlAdapter.new(secret_name: service_slug,
-                                           namespace: ENV['KUBECTL_SERVICES_NAMESPACE'])
+                                           namespace: namespace)
     adapter.get_public_key
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   get '/health', to: 'health#show'
-  get '/service/:service_slug', to: 'service_token#show'
   get '/service/v2/:service_slug', to: 'service_token_v2#show'
+  get '/v3/applications/:application/namespaces/:namespace', to: 'service_token_v3#show'
 end

--- a/spec/controllers/service_token_v3_controller_spec.rb
+++ b/spec/controllers/service_token_v3_controller_spec.rb
@@ -1,20 +1,20 @@
 require 'rails_helper'
 
-RSpec.describe ServiceTokenV2Controller do
+RSpec.describe ServiceTokenV3Controller do
   describe '#show' do
     it 'returns public key' do
-      allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('v2-public-key')
+      allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('v3-public-key')
 
-      get :show, params: { service_slug: 'test-service' }
+      get :show, params: { application: 'test-service', namespace: 'basset-hound' }
       expect(response).to be_successful
-      expect(JSON.parse(response.body)['token']).to eql('v2-public-key')
+      expect(JSON.parse(response.body)['token']).to eql('v3-public-key')
     end
 
     context 'when service does not exist' do
       it 'returns 404' do
         allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('')
 
-        get :show, params: { service_slug: 'test-service' }
+        get :show, params: { application: 'test-service', namespace: 'basset-hound' }
         expect(response).to be_not_found
       end
     end
@@ -23,8 +23,8 @@ RSpec.describe ServiceTokenV2Controller do
       before do
         ENV.stub(:[])
         ENV.stub(:[]).with('IGNORE_CACHE').and_return('true')
-        allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('v2-public-key')
-        get :show, params: { service_slug: 'test-service' }
+        allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('v3-public-key')
+        get :show, params: { application: 'test-service', namespace: 'basset-hound' }
       end
 
       it 'should return the public key without using the redis cache' do

--- a/spec/services/adapters/kubectl_adapter_spec.rb
+++ b/spec/services/adapters/kubectl_adapter_spec.rb
@@ -44,5 +44,17 @@ describe Adapters::KubectlAdapter do
         end
       end
     end
+
+    context 'when a CmdFailedError is raised' do
+      subject do
+        described_class.new(secret_name: 'some-secret', namespace: 'some-namespace')
+      end
+
+      it 'should rescue and return empty string' do
+        allow(Adapters::ShellAdapter).to receive(:output_of).and_raise(CmdFailedError)
+
+        expect(subject.get_public_key).to eq('')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Add V3 service controller

We need to pass a namespace to the service token cache as we are expanding the use of JWT tokens to be cross namespace, not just the services namespace.

## Rescue CmdFailedError when kubectl command fails

In the instances of a request such as GET service/v3/foo/bar both the service and the namespace do not exist. The kubectl command will fail with a 500 and we raise a CmdFailedError. We want to rescue this and actually return and empty string which we translate into a 404 for the requesting service.

We feel this is more accurate for what is actually happening. We only rescue the CmdFailedError so an actual 500 error will still respond correctly.

https://trello.com/c/XABkwrLb/1017-create-v3-service-token-cache-endpoint

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>