### PR TITLE
Add permission to formbuilder saas namespace

### DIFF
--- a/deploy/fb-service-token-cache-chart/templates/network_policy.yaml
+++ b/deploy/fb-service-token-cache-chart/templates/network_policy.yaml
@@ -26,3 +26,10 @@ spec:
     ports:
     - protocol: TCP
       port: 3000
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: formbuilder-saas-{{ .Values.platformEnv }}
+    ports:
+    - protocol: TCP
+      port: 3000


### PR DESCRIPTION
This enables for applications in formbuilder-saas namespace to
make requests to the service token cache app