### PR TITLE
Cater for ignore_cache query param

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,6 @@
 class ApplicationController < ActionController::API
+  def ignore_cache
+    ActiveModel::Type::Boolean.new.cast(params[:ignore_cache]) ||
+      ActiveModel::Type::Boolean.new.cast(ENV['IGNORE_CACHE'])
+  end
 end

--- a/app/controllers/service_token_v2_controller.rb
+++ b/app/controllers/service_token_v2_controller.rb
@@ -1,6 +1,6 @@
 class ServiceTokenV2Controller < ApplicationController
   def show
-    service = PublicKeyService.new(service_slug: params[:service_slug])
+    service = PublicKeyService.new(service_slug: params[:service_slug], ignore_cache: ignore_cache)
     public_key = service.call
 
     if public_key.present?

--- a/app/controllers/service_token_v3_controller.rb
+++ b/app/controllers/service_token_v3_controller.rb
@@ -2,7 +2,8 @@ class ServiceTokenV3Controller < ApplicationController
   def show
     service = PublicKeyService.new(
       service_slug: params[:application],
-      namespace: params[:namespace]
+      namespace: params[:namespace],
+      ignore_cache: ignore_cache
     )
     public_key = service.call
 

--- a/app/services/public_key_service.rb
+++ b/app/services/public_key_service.rb
@@ -1,13 +1,14 @@
 class PublicKeyService
-  attr_reader :service_slug, :namespace
+  attr_reader :service_slug, :namespace, :ignore_cache
 
-  def initialize(service_slug:, namespace: ENV['KUBECTL_SERVICES_NAMESPACE'])
+  def initialize(service_slug:, namespace: ENV['KUBECTL_SERVICES_NAMESPACE'], ignore_cache:)
     @service_slug = service_slug
     @namespace = namespace
+    @ignore_cache = ignore_cache
   end
 
   def call
-    if ActiveModel::Type::Boolean.new.cast(ENV['IGNORE_CACHE'])
+    if ignore_cache
       public_key
     else
       if cached_value

--- a/spec/controllers/service_token_v2_controller_spec.rb
+++ b/spec/controllers/service_token_v2_controller_spec.rb
@@ -2,10 +2,12 @@ require 'rails_helper'
 
 RSpec.describe ServiceTokenV2Controller do
   describe '#show' do
+    let(:params) { { service_slug: 'test-service' } }
+
     it 'returns public key' do
       allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('v2-public-key')
 
-      get :show, params: { service_slug: 'test-service' }
+      get :show, params: params
       expect(response).to be_successful
       expect(JSON.parse(response.body)['token']).to eql('v2-public-key')
     end
@@ -14,7 +16,7 @@ RSpec.describe ServiceTokenV2Controller do
       it 'returns 404' do
         allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('')
 
-        get :show, params: { service_slug: 'test-service' }
+        get :show, params: params
         expect(response).to be_not_found
       end
     end
@@ -24,13 +26,25 @@ RSpec.describe ServiceTokenV2Controller do
         ENV.stub(:[])
         ENV.stub(:[]).with('IGNORE_CACHE').and_return('true')
         allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('v2-public-key')
-        get :show, params: { service_slug: 'test-service' }
+        get :show, params: params
       end
 
       it 'should return the public key without using the redis cache' do
         expect(response).to be_successful
         expect(Adapters::RedisCacheAdapter).not_to receive(:get)
         expect(Adapters::RedisCacheAdapter).not_to receive(:put)
+      end
+    end
+
+    context 'when ignore_cache query param is present' do
+      before do
+        allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('v2-public-key')
+        get :show, params: params.merge(ignore_cache: 'true')
+      end
+
+      it 'should return the public key without using the redis cache' do
+        expect(response).to be_successful
+        expect(ENV).not_to receive(:[]).with('IGNORE_CACHE')
       end
     end
   end

--- a/spec/controllers/service_token_v3_controller_spec.rb
+++ b/spec/controllers/service_token_v3_controller_spec.rb
@@ -2,10 +2,12 @@ require 'rails_helper'
 
 RSpec.describe ServiceTokenV3Controller do
   describe '#show' do
+    let(:params) { { application: 'test-service', namespace: 'basset-hound' } }
+
     it 'returns public key' do
       allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('v3-public-key')
 
-      get :show, params: { application: 'test-service', namespace: 'basset-hound' }
+      get :show, params: params
       expect(response).to be_successful
       expect(JSON.parse(response.body)['token']).to eql('v3-public-key')
     end
@@ -14,7 +16,7 @@ RSpec.describe ServiceTokenV3Controller do
       it 'returns 404' do
         allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('')
 
-        get :show, params: { application: 'test-service', namespace: 'basset-hound' }
+        get :show, params: params
         expect(response).to be_not_found
       end
     end
@@ -24,13 +26,25 @@ RSpec.describe ServiceTokenV3Controller do
         ENV.stub(:[])
         ENV.stub(:[]).with('IGNORE_CACHE').and_return('true')
         allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('v3-public-key')
-        get :show, params: { application: 'test-service', namespace: 'basset-hound' }
+        get :show, params: params
       end
 
       it 'should return the public key without using the redis cache' do
         expect(response).to be_successful
         expect(Adapters::RedisCacheAdapter).not_to receive(:get)
         expect(Adapters::RedisCacheAdapter).not_to receive(:put)
+      end
+    end
+
+    context 'when ignore cache query param is present' do
+      before do
+        allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('v3-public-key')
+        get :show, params: params.merge(ignore_cache: 'true')
+      end
+
+      it 'should return the public key without using the redis cache' do
+        expect(response).to be_successful
+        expect(ENV).not_to receive(:[]).with('IGNORE_CACHE')
       end
     end
   end


### PR DESCRIPTION
We need to be able to cater for rotating the public keys. The service token cache has the `IGNORE_CACHE` environment variable which we could set to 'true' and then deploy the app out. However that would mean that every request received for every app would hit Kubernetes.

Passing an `ignore_cache` query parameter allows us to be more flexible when requesting the public key from Kubernetes. We only need to do so for the specific app that needs it instead of all of them at the same time

https://trello.com/c/zz1K8m9d/1039-add-ability-to-rotate-public-keys-in-the-api-without-downtime