### PR TITLE
Use service_slug for consistency

### DIFF
--- a/app/controllers/service_token_v3_controller.rb
+++ b/app/controllers/service_token_v3_controller.rb
@@ -1,7 +1,7 @@
 class ServiceTokenV3Controller < ApplicationController
   def show
     service = PublicKeyService.new(
-      service_slug: params[:application],
+      service_slug: params[:service_slug],
       namespace: params[:namespace],
       ignore_cache: ignore_cache
     )

--- a/app/services/adapters/kubectl_adapter.rb
+++ b/app/services/adapters/kubectl_adapter.rb
@@ -1,8 +1,8 @@
 class Adapters::KubectlAdapter
-  attr_reader :secret_name, :namespace
+  attr_reader :service_slug, :namespace
 
-  def initialize(secret_name:, namespace:)
-    @secret_name = secret_name
+  def initialize(service_slug:, namespace:)
+    @service_slug = service_slug
     @namespace = namespace
 
     validate_params!
@@ -15,7 +15,7 @@ class Adapters::KubectlAdapter
       'configmaps',
       '-o',
       "jsonpath='{.data.ENCODED_PUBLIC_KEY}'",
-      "fb-#{secret_name}-config-map",
+      "fb-#{service_slug}-config-map",
     ] + [kubectl_args]
 
     Adapters::ShellAdapter.output_of(command)
@@ -27,8 +27,8 @@ class Adapters::KubectlAdapter
   private
 
   def validate_params!
-    if !secret_name.match(/\A[a-zA-Z0-9\-_]*\z/)
-      raise ArgumentError.new('rejected potentially dangerous secret_name')
+    if !service_slug.match(/\A[a-zA-Z0-9\-_]*\z/)
+      raise ArgumentError.new('rejected potentially dangerous service_slug')
     end
 
     if !namespace.match(/\A[a-zA-Z0-9\-_]*\z/)

--- a/app/services/support/service_token_authoritative_source.rb
+++ b/app/services/support/service_token_authoritative_source.rb
@@ -1,6 +1,6 @@
 class Support::ServiceTokenAuthoritativeSource
   def self.get_public_key(service_slug:, namespace:)
-    adapter = Adapters::KubectlAdapter.new(secret_name: service_slug,
+    adapter = Adapters::KubectlAdapter.new(service_slug: service_slug,
                                            namespace: namespace)
     adapter.get_public_key
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   get '/health', to: 'health#show'
   get '/service/v2/:service_slug', to: 'service_token_v2#show'
-  get '/v3/applications/:application/namespaces/:namespace', to: 'service_token_v3#show'
+  get '/v3/applications/:service_slug/namespaces/:namespace', to: 'service_token_v3#show'
 end

--- a/spec/controllers/service_token_v3_controller_spec.rb
+++ b/spec/controllers/service_token_v3_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ServiceTokenV3Controller do
   describe '#show' do
-    let(:params) { { application: 'test-service', namespace: 'basset-hound' } }
+    let(:params) { { service_slug: 'test-service', namespace: 'basset-hound' } }
 
     it 'returns public key' do
       allow(Support::ServiceTokenAuthoritativeSource).to receive(:get_public_key).and_return('v3-public-key')

--- a/spec/services/adapters/kubectl_adapter_spec.rb
+++ b/spec/services/adapters/kubectl_adapter_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Adapters::KubectlAdapter do
-  let(:secret_name) { 'my-secret' }
+  let(:service_slug) { 'my-service-slug' }
   let(:namespace) { 'my-namespace' }
 
   before do
@@ -9,17 +9,17 @@ describe Adapters::KubectlAdapter do
   end
 
   subject do
-    described_class.new(secret_name: secret_name, namespace: namespace)
+    described_class.new(service_slug: service_slug, namespace: namespace)
   end
 
   describe '#get_public_key' do
     context 'when code injection' do
-      context 'with dangerous secret_name' do
-        let(:secret_name) { '; curl https://example.com;' }
+      context 'with dangerous service_slug' do
+        let(:service_slug) { '; curl https://example.com;' }
         let(:namespace) { 'some-namespace' }
 
         subject do
-          described_class.new(secret_name: secret_name, namespace: namespace)
+          described_class.new(service_slug: service_slug, namespace: namespace)
         end
 
         it 'raises an error' do
@@ -30,11 +30,11 @@ describe Adapters::KubectlAdapter do
       end
 
       context 'with dangerous namespace' do
-        let(:secret_name) { 'some-namespace' }
+        let(:service_slug) { 'some-namespace' }
         let(:namespace) { '; curl https://example.com;' }
 
         subject do
-          described_class.new(secret_name: secret_name, namespace: namespace)
+          described_class.new(service_slug: service_slug, namespace: namespace)
         end
 
         it 'raises an error' do
@@ -47,7 +47,7 @@ describe Adapters::KubectlAdapter do
 
     context 'when a CmdFailedError is raised' do
       subject do
-        described_class.new(secret_name: 'some-secret', namespace: 'some-namespace')
+        described_class.new(service_slug: 'some-secret', namespace: 'some-namespace')
       end
 
       it 'should rescue and return empty string' do


### PR DESCRIPTION
The same property is referenced across the platform using several different things but it always represents the same thing.

Eventually the actual thing that the request to the service token cache is trying to retrieve is the public key from Kubernetes or from the Redis if it has already been cached there.

The service slug is a parameterized version of the service name. But with version 3 of the service token cache endpoint the service_slug could also be related to a platform app, not just a form.

In Redis the key which is used takes the form:

`encoded-public-key-<service_slug>`

e.g `encoded-public-key-apply-financial-deputy`

And then if the cache has expired then the request to Kubernetes will look for a config map, _not_ a secret, which takes the form:

`fb-<service_slug>-config-map`

e.g

`fb-apply-financial-deputy-config-map`

The name of this config map is created during the deployment of the platform application or the service so it has to match that.

Regardless, service_slug seems like a more universal description as opposed to application and definitely is a lot more accurate than secret_name as at no point does the service token cache ever request a kubernetes secret.