### PR TITLE
Bump mime magic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
Version 0.3.5 was yanked
https://rubygems.org/gems/mimemagic/versions/0.3.5