### PR TITLE
Migrate to use new Sentry gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,8 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'rails', '~> 6.1.3'
 gem 'puma', '~> 5.3'
 gem 'redis', '~> 4.2'
-gem 'sentry-raven'
+gem 'sentry-rails', '~> 4.4.0'
+gem 'sentry-ruby', '~> 4.4.2'
 gem 'jwt'
 gem 'sqlite3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,11 +80,15 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.3.0)
+    faraday (1.4.1)
+      faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
+    faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
     ffi (1.15.0)
     formatador (0.2.5)
     globalid (0.4.2)
@@ -192,8 +196,16 @@ GEM
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
     ruby2_keywords (0.0.4)
-    sentry-raven (3.1.2)
+    sentry-rails (4.4.0)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.4.0.pre.beta)
+    sentry-ruby (4.4.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.4.2)
+    sentry-ruby-core (4.4.2)
+      concurrent-ruby
+      faraday
     shellany (0.0.1)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
@@ -241,7 +253,8 @@ DEPENDENCIES
   rails (~> 6.1.3)
   redis (~> 4.2)
   rspec-rails (>= 3.5.0)
-  sentry-raven
+  sentry-rails (~> 4.4.0)
+  sentry-ruby (~> 4.4.2)
   shoulda-matchers (~> 4.5)
   simplecov
   simplecov-console

--- a/app/services/adapters/kubectl_adapter.rb
+++ b/app/services/adapters/kubectl_adapter.rb
@@ -20,7 +20,7 @@ class Adapters::KubectlAdapter
 
     Adapters::ShellAdapter.output_of(command)
   rescue CmdFailedError => e
-    Raven.capture_exception(e)
+    Sentry.capture_exception(e)
     ''
   end
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,13 @@
-Raven.configure do |config|
-  config.dsn = ENV['SENTRY_DSN']
-  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+Sentry.init do |config|
+  config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+  config.logger =  Logger.new(STDOUT)
+
+  config.traces_sample_rate = 1
+  config.before_send = lambda do |event, _hint|
+    if event.request && event.request.data
+      filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+      event.request.data = filter.filter(event.request.data)
+    end
+    event
+  end
 end


### PR DESCRIPTION
This adds the new sentry rails and ruby gems.

Configure the cleaning of the sensitive parameters.

Also enable performance monitoring for the upcoming trial.