### PR TITLE
Add horizontal autoscaling configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           only_for_branches: master
           failure_message: ":facepalm:  Failed job $CIRCLE_JOB  :homer-disappear:"
           include_job_number_field: false
-  build_and_deploy_to_test:
+  build_and_push_image:
     working_directory: ~/circle/git/fb-service-token-cache
     docker: &ecr_base_image
       - image: $AWS_BUILD_IMAGE_ECR_ACCOUNT_URL
@@ -29,9 +29,6 @@ jobs:
           aws_secret_access_key: $AWS_BUILD_IMAGE_SECRET_ACCESS_KEY
     steps:
       - checkout
-      - add_ssh_keys: &ssh_keys
-          fingerprints:
-            - "e3:25:34:15:2b:c4:d3:b7:c3:94:9f:50:dd:c3:0f:de"
       - run: &base_environment_variables
           name: Setup base environment variable
           command: |
@@ -46,6 +43,16 @@ jobs:
           environment:
             ENVIRONMENT_NAME: test
           command: './deploy-scripts/bin/build'
+  deploy_to_test_dev:
+    working_directory: ~/circle/git/fb-service-token-cache
+    docker: *ecr_base_image
+    steps:
+      - checkout
+      - add_ssh_keys: &ssh_keys
+          fingerprints:
+            - "e3:25:34:15:2b:c4:d3:b7:c3:94:9f:50:dd:c3:0f:de"
+      - run: *base_environment_variables
+      - run: *deploy_scripts
       - run:
           name: deploy to test dev
           environment:
@@ -54,6 +61,15 @@ jobs:
             DEPLOYMENT_ENV: dev
             K8S_NAMESPACE: formbuilder-platform-test-dev
           command: './deploy-scripts/bin/deploy'
+      - slack/status: *slack_status
+  deploy_to_test_production:
+    working_directory: ~/circle/git/fb-service-token-cache
+    docker: *ecr_base_image
+    steps:
+      - checkout
+      - add_ssh_keys: *ssh_keys
+      - run: *base_environment_variables
+      - run: *deploy_scripts
       - run:
           name: deploy to test production
           environment:
@@ -62,6 +78,15 @@ jobs:
             DEPLOYMENT_ENV: production
             K8S_NAMESPACE: formbuilder-platform-test-production
           command: './deploy-scripts/bin/deploy'
+      - slack/status: *slack_status
+  deploy_to_test_dev_eks:
+    working_directory: ~/circle/git/fb-service-token-cache
+    docker: *ecr_base_image
+    steps:
+      - checkout
+      - add_ssh_keys: *ssh_keys
+      - run: *base_environment_variables
+      - run: *deploy_scripts
       - run:
           name: deploy to test dev (EKS cluster)
           environment:
@@ -70,6 +95,15 @@ jobs:
             DEPLOYMENT_ENV: dev
             K8S_NAMESPACE: formbuilder-platform-test-dev
           command: './deploy-scripts/bin/deploy-eks'
+      - slack/status: *slack_status
+  deploy_to_test_production_eks:
+    working_directory: ~/circle/git/fb-service-token-cache
+    docker: *ecr_base_image
+    steps:
+      - checkout
+      - add_ssh_keys: *ssh_keys
+      - run: *base_environment_variables
+      - run: *deploy_scripts
       - run:
           name: deploy to test production (EKS cluster)
           environment:
@@ -79,7 +113,7 @@ jobs:
             K8S_NAMESPACE: formbuilder-platform-test-production
           command: './deploy-scripts/bin/deploy-eks'
       - slack/status: *slack_status
-  build_and_deploy_to_live:
+  deploy_to_live_dev:
     working_directory: ~/circle/git/fb-service-token-cache
     docker: *ecr_base_image
     steps:
@@ -89,11 +123,6 @@ jobs:
       - run: *base_environment_variables
       - run: *deploy_scripts
       - run:
-          name: build and push docker images
-          environment:
-            ENVIRONMENT_NAME: live
-          command: './deploy-scripts/bin/build'
-      - run:
           name: deploy to live dev
           environment:
             APPLICATION_NAME: fb-service-token-cache
@@ -101,6 +130,20 @@ jobs:
             DEPLOYMENT_ENV: dev
             K8S_NAMESPACE: formbuilder-platform-live-dev
           command: './deploy-scripts/bin/deploy'
+      - slack/status:
+          only_for_branches: master
+          success_message: ":rocket:  Successfully deployed to Live Dev  :guitar:"
+          failure_message: ":alert:  Failed to deploy to Live Dev  :try_not_to_cry:"
+          include_job_number_field: false
+  deploy_to_live_production:
+    working_directory: ~/circle/git/fb-service-token-cache
+    docker: *ecr_base_image
+    steps:
+      - checkout
+      - add_ssh_keys: *ssh_keys
+      - setup_remote_docker
+      - run: *base_environment_variables
+      - run: *deploy_scripts
       - run:
           name: deploy to live production
           environment:
@@ -111,8 +154,8 @@ jobs:
           command: './deploy-scripts/bin/deploy'
       - slack/status:
           only_for_branches: master
-          success_message: ":rocket:  Successfully deployed to Live  :guitar:"
-          failure_message: ":alert:  Failed to deploy to Live  :try_not_to_cry:"
+          success_message: ":rocket:  Successfully deployed to Live Production  :guitar:"
+          failure_message: ":alert:  Failed to deploy to Live Production  :try_not_to_cry:"
           include_job_number_field: false
   acceptance_tests:
     docker: *ecr_base_image
@@ -139,23 +182,40 @@ workflows:
   test_and_build:
     jobs:
       - test
-      - build_and_deploy_to_test:
+      - build_and_push_image:
           requires:
             - test
           filters:
             branches:
               only:
                 - master
+      - deploy_to_test_dev:
+          requires:
+            - build_and_push_image
+      - deploy_to_test_production:
+          requires:
+            - build_and_push_image
+      - deploy_to_test_dev_eks:
+          requires:
+            - build_and_push_image
+      - deploy_to_test_production_eks:
+          requires:
+            - build_and_push_image
       - acceptance_tests:
           requires:
-            - test
-            - build_and_deploy_to_test
+            - deploy_to_test_dev
+            - deploy_to_test_production
           filters:
             branches:
-              only: master
-      - build_and_deploy_to_live:
+              only:
+                - master
+      - deploy_to_live_dev:
+          requires:
+            - acceptance_tests
+      - deploy_to_live_production:
           requires:
             - acceptance_tests
       - smoke_tests:
           requires:
-            - build_and_deploy_to_live
+            - deploy_to_live_dev
+            - deploy_to_live_production

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -2,4 +2,10 @@ class HealthController < ApplicationController
   def show
     render plain: 'healthy'
   end
+
+  def readiness
+    if Adapters::RedisCacheAdapter.connection.ping
+      render plain: 'ready'
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
-  get '/health', to: 'health#show'
+  get '/health', to: 'health#show' # used for liveness probe
+  get '/readiness', to: 'health#readiness'
   get '/service/v2/:service_slug', to: 'service_token_v2#show'
   get '/v3/applications/:service_slug/namespaces/:namespace', to: 'service_token_v3#show'
 end

--- a/deploy-eks/fb-service-token-cache-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-service-token-cache-chart/templates/deployment.yaml
@@ -5,12 +5,12 @@ kind: Deployment
 metadata:
   name: "fb-service-token-cache-{{ .Values.environmentName }}"
 spec:
-  replicas: 2
+  replicas: {{ .Values.replicas }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 100%
-      maxUnavailable: 50%
+      maxSurge: {{ .Values.strategy.maxSurge }}
+      maxUnavailable: {{ .Values.strategy.maxUnavailable }}
   selector:
     matchLabels:
       app: "fb-service-token-cache-{{ .Values.environmentName }}"
@@ -30,13 +30,20 @@ spec:
         imagePullPolicy: Always
         ports:
           - containerPort: 3000
-        readinessProbe:
+        livenessProbe:
           httpGet:
             path: /health
             port: 3000
-          initialDelaySeconds: 15
-          periodSeconds: 5
-          successThreshold: 1
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 3000
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
 
         # non-secret env vars
         # defined in config_map.yaml

--- a/deploy-eks/fb-service-token-cache-chart/templates/hpa.yaml
+++ b/deploy-eks/fb-service-token-cache-chart/templates/hpa.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.hpa }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: fb-service-token-cache-{{ .Values.environmentName }}
+  namespace: formbuilder-platform-{{ .Values.environmentName }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fb-service-token-cache-{{ .Values.environmentName }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/fb-service-token-cache-chart/templates/deployment.yaml
+++ b/deploy/fb-service-token-cache-chart/templates/deployment.yaml
@@ -28,14 +28,25 @@ spec:
         securityContext:
           runAsUser: 1001
         imagePullPolicy: Always
+        lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep", "10"]
         ports:
           - containerPort: 3000
-        readinessProbe:
+        livenessProbe:
           httpGet:
             path: /health
             port: 3000
           initialDelaySeconds: 15
           periodSeconds: 5
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 3000
+          initialDelaySeconds: 15
+          periodSeconds: 30
           successThreshold: 1
 
         # non-secret env vars

--- a/deploy/fb-service-token-cache-chart/templates/deployment.yaml
+++ b/deploy/fb-service-token-cache-chart/templates/deployment.yaml
@@ -5,12 +5,12 @@ kind: Deployment
 metadata:
   name: "fb-service-token-cache-{{ .Values.environmentName }}"
 spec:
-  replicas: 2
+  replicas: {{ .Values.replicas }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 100%
-      maxUnavailable: 50%
+      maxSurge: {{ .Values.strategy.maxSurge }}
+      maxUnavailable: {{ .Values.strategy.maxUnavailable }}
   selector:
     matchLabels:
       app: "fb-service-token-cache-{{ .Values.environmentName }}"
@@ -38,16 +38,16 @@ spec:
           httpGet:
             path: /health
             port: 3000
-          initialDelaySeconds: 15
-          periodSeconds: 5
-          successThreshold: 1
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
         readinessProbe:
           httpGet:
             path: /readiness
             port: 3000
-          initialDelaySeconds: 15
-          periodSeconds: 30
-          successThreshold: 1
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
 
         # non-secret env vars
         # defined in config_map.yaml

--- a/deploy/fb-service-token-cache-chart/templates/hpa.yaml
+++ b/deploy/fb-service-token-cache-chart/templates/hpa.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.hpa }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: fb-service-token-cache-{{ .Values.environmentName }}
+  namespace: formbuilder-platform-{{ .Values.environmentName }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fb-service-token-cache-{{ .Values.environmentName }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}


### PR DESCRIPTION
## Add readiness probe

This will check that there is an active connection to Redis before
allowing any traffic to be routed to a new container
 
## Add the Horizontal Autoscaling config

This adds the ability for horizontal autoscaling to be done in both the
old cluster and the EKS cluster on a per namespace basis.
 
## Use deploy repo values in deployment config

These can now be set individually per namespace using the
fb-service-token-cache-deploy repo
 
## Update circle config

Parallelise the deployments to the dev and production namespaces in both
Test and Live.

![Screenshot 2022-02-15 at 12 26 01](https://user-images.githubusercontent.com/3466862/154067849-c929ff84-2195-4de7-88e1-ae58606923af.png)

