### PR TITLE
Unpin Docker version in CircleCI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker: &remote_docker
-          version: 20.10.11
           docker_layer_caching: true
       - run:
           name: test


### PR DESCRIPTION
CircleCI will keep the Docker executor up to date on a rolling basis.

[CircleCi run](https://app.circleci.com/pipelines/github/ministryofjustice/fb-service-token-cache/1043/workflows/72573848-60a9-4c84-9bc9-f21793f70ef1)