### PR TITLE
Added limits to test add more cpu than the 250 default.

### DIFF
--- a/deploy-eks/fb-service-token-cache-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-service-token-cache-chart/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
         resources:
           requests:
             cpu: {{ .Values.resources.requests.cpu }}
+          limits:
+            cpu: {{ .Values.resources.limits.cpu }}
         # non-secret env vars
         # defined in config_map.yaml
         envFrom:


### PR DESCRIPTION
This is for testing if changing the limits in the deployment template will allow increasing the cpu past the default.